### PR TITLE
Enable sinkhorn DA loss

### DIFF
--- a/sbi/inference/posteriors/direct_posterior.py
+++ b/sbi/inference/posteriors/direct_posterior.py
@@ -93,6 +93,12 @@ class DirectPosterior(NeuralPosterior):
         self._purpose = """It samples the posterior network and rejects samples that
             lie outside of the prior bounds."""
 
+    def embed_x(self, x: Tensor) -> Tensor:
+        """Return latent vector of ``x`` using the posterior's embedding network."""
+        if hasattr(self.posterior_estimator, "embed_condition"):
+            return self.posterior_estimator.embed_condition(x)
+        raise AttributeError("Posterior estimator has no embedding network")
+
     def to(self, device: Union[str, torch.device]) -> None:
         """Move posterior_estimator, prior and x_o to device.
 

--- a/sbi/inference/trainers/npe/domain_adaptation_loss.py
+++ b/sbi/inference/trainers/npe/domain_adaptation_loss.py
@@ -1,0 +1,73 @@
+from typing import Callable
+
+import torch
+from torch import Tensor, nn
+from geomloss import SamplesLoss
+from sbi.inference.trainers.npe.npe_base import PosteriorEstimatorTrainer
+
+from sbi.neural_nets.estimators.shape_handling import reshape_to_batch_event
+
+
+def make_sinkhorn_loss(trainer: "PosteriorEstimatorTrainer") -> Callable:
+    """Return a custom loss for domain adaptation using Sinkhorn divergence.
+
+    The returned function expects that each training batch contains simulation
+    outputs ``x`` where the first half corresponds to the source domain
+    (paired with ``theta``) and the second half to the target domain. Only the
+    source samples are used for the log-probability term.
+    """
+
+    device = trainer._device
+    eta_1 = nn.Parameter(torch.tensor(1.0, device=device))
+    eta_2 = nn.Parameter(torch.tensor(1.0, device=device))
+    sinkhorn_fn: Callable[[Tensor, Tensor, float], Tensor]
+
+    def custom_loss(
+        theta: Tensor,
+        x: Tensor,
+        masks: Tensor,
+        proposal,
+        calibration_kernel: Callable[[Tensor], Tensor],
+        force_first_round_loss: bool = False,
+    ) -> Tensor:
+        nonlocal sinkhorn_fn
+
+        batch_size = theta.shape[0]
+        source_x = x[:batch_size]
+        target_x = x[batch_size:]
+        masks = masks[:batch_size]
+
+        theta_b = reshape_to_batch_event(theta, event_shape=trainer._neural_net.input_shape)
+        source_x_b = reshape_to_batch_event(
+            source_x, event_shape=trainer._neural_net.condition_shape
+        )
+
+        if trainer._round == 0 or force_first_round_loss:
+            base_loss = trainer._neural_net.loss(theta_b, source_x_b)
+        else:
+            base_loss = -trainer._log_prob_proposal_posterior(
+                theta, source_x, masks, proposal
+            )
+
+        src_feat = trainer._neural_net.embed_condition(source_x_b)
+        tgt_feat = trainer._neural_net.embed_condition(
+            reshape_to_batch_event(target_x, trainer._neural_net.condition_shape)
+        )
+
+        with torch.no_grad():
+            max_distance = torch.max(torch.cdist(src_feat, tgt_feat, p=2))
+            blur = max(0.05 * max_distance.item(), 0.01)
+            sinkhorn_fn = SamplesLoss("sinkhorn", blur=blur, scaling=0.9)
+
+        da_loss = sinkhorn_fn(src_feat, tgt_feat)
+
+        total = (
+            (1.0 / (2 * eta_1**2)) * base_loss
+            + (1.0 / (2 * eta_2**2)) * da_loss
+            + torch.log(torch.abs(eta_1) * torch.abs(eta_2))
+        )
+
+        return calibration_kernel(source_x) * total
+
+    return custom_loss
+

--- a/sbi/inference/trainers/npe/npe_base.py
+++ b/sbi/inference/trainers/npe/npe_base.py
@@ -228,6 +228,7 @@ class PosteriorEstimatorTrainer(NeuralInference, ABC):
         retrain_from_scratch: bool = False,
         show_train_summary: bool = False,
         dataloader_kwargs: Optional[dict] = None,
+        custom_loss: Optional[Callable] = None,
     ) -> ConditionalDensityEstimator:
         r"""Return density estimator that approximates the distribution $p(\theta|x)$.
 
@@ -261,6 +262,8 @@ class PosteriorEstimatorTrainer(NeuralInference, ABC):
                 loss after the training.
             dataloader_kwargs: Additional or updated kwargs to be passed to the training
                 and validation dataloaders (like, e.g., a collate_fn)
+            custom_loss: Optional callable overriding the default loss function.
+                It must have the same signature as ``self._loss``.
 
         Returns:
             Density estimator that approximates the distribution $p(\theta|x)$.
@@ -360,7 +363,8 @@ class PosteriorEstimatorTrainer(NeuralInference, ABC):
                     batch[2].to(self._device),
                 )
 
-                train_losses = self._loss(
+                loss_fn = custom_loss or self._loss
+                train_losses = loss_fn(
                     theta_batch,
                     x_batch,
                     masks_batch,
@@ -397,7 +401,8 @@ class PosteriorEstimatorTrainer(NeuralInference, ABC):
                         batch[2].to(self._device),
                     )
                     # Take negative loss here to get validation log_prob.
-                    val_losses = self._loss(
+                    loss_fn = custom_loss or self._loss
+                    val_losses = loss_fn(
                         theta_batch,
                         x_batch,
                         masks_batch,

--- a/sbi/neural_nets/estimators/base.py
+++ b/sbi/neural_nets/estimators/base.py
@@ -151,6 +151,24 @@ class ConditionalDensityEstimator(ConditionalEstimator):
         r"""Return the embedding network if it exists."""
         return None
 
+    def embed_condition(self, condition: Tensor) -> Tensor:
+        """Return latent representation from the embedding network.
+
+        If no embedding network is present, the input is returned unchanged.
+        """
+        if self.embedding_net is None:
+            return condition
+        return self.embedding_net(condition)
+
+    def forward_with_latent(self, input: Tensor, condition: Tensor):
+        """Return latent representation and model output for ``input``.
+
+        This utility can be overridden by subclasses to return quantities used
+        for custom losses, e.g. domain adaptation losses requiring access to the
+        embedding features alongside the density estimator output.
+        """
+        raise NotImplementedError
+
     @abstractmethod
     def log_prob(self, input: Tensor, condition: Tensor, **kwargs) -> Tensor:
         r"""Return the log probabilities of the inputs given a condition or multiple


### PR DESCRIPTION
## Summary
- add `make_sinkhorn_loss` utility for custom domain adaptation losses

## Testing
- `python -m py_compile sbi/inference/trainers/npe/domain_adaptation_loss.py`
- `python -m py_compile sbi/inference/trainers/npe/npe_base.py`
- `python -m py_compile sbi/neural_nets/estimators/base.py`
- `python -m py_compile sbi/neural_nets/estimators/nflows_flow.py`
- `python -m py_compile sbi/neural_nets/estimators/zuko_flow.py`
- `python -m py_compile sbi/inference/posteriors/direct_posterior.py`
- `pytest tests/circular_import_test.py::test_imports -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6848a7b9d7a0832e996e04db7e282638